### PR TITLE
Switch to activeTab permission.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,13 +1,12 @@
 {
   "name": "Copy as Markdown",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
     "tabs",
     "contextMenus",
-    "http://*/*",
-    "https://*/*",
+    "activeTab",
     "storage"
   ],
   "browser_action": {


### PR DESCRIPTION
All functionality seems to work fine with the activeTab permission instead of the URL-based permissions, and avoids scary warnings about "access all your data" when installing. (Closes #14)
"tabs" is still needed to do the multi-tab link lists.
 