### PR TITLE
Fixed/added ability to grab link or image descriptions [time 23:43]

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,53 @@
+// context menu event detection
+var contextInfo = {
+   anchorElem: null,
+   imgElem: null,
+   src: null,
+   alt: null,
+   innerText: null,
+   href: null,
+};
+
+document.addEventListener("contextmenu", function(e) {
+   var elem = e.target;
+   var innerText, href, alt, src;
+   // If target was an image
+   if (elem instanceof HTMLImageElement) {
+      contextInfo.imgElem = elem.target;
+      src = elem.src;
+      alt = elem.getAttribute('alt');
+      console.log("sfinktah: received right-click for ![" + alt + "](" + src + ")");
+      // It won't send whole elements
+      contextInfo.src = src;
+      contextInfo.alt = alt;
+   }
+   // regardless, also traverse up tree for a containing `<a href>`
+   while (elem) {
+      if (elem instanceof HTMLAnchorElement) {
+         var href = elem.href;
+         if (elem.innerText == null) {
+            innerText = '';
+         } else {
+            innerText = elem.innerText.trim();
+         }
+         console.log("sfinktah: received right-click for [" + innerText + "](" + href + ")");
+
+         // It won't send whole elements 
+         // contextInfo.anchorElem = elem;
+         contextInfo.innerText = innerText;
+         contextInfo.href = href;
+         break;
+      } else {
+         elem = elem.parentNode;
+      }
+   }
+}, {
+   capture: true,
+   passive: true 
+});
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if(request == "getContextInfo") {
+        sendResponse(contextInfo);
+    }
+});

--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -23,21 +23,49 @@ chrome.contextMenus.create({
     // auto discover image
     var linkText = "";
     var needEscape = true;
+    var contextInfo = {};
 
-    if (info.mediaType === "image") {
-      needEscape = false;
-      linkText = "![]("+info.srcUrl+")";
-    } else {
-      linkText = info.selectionText;
-    }
+    chrome.tabs.sendMessage(tab.id, "getContextInfo", function(result) {
+      contextInfo.data = result;
+      console.log('contextMenu.onclick: info, tab, contextInfo', info, tab, contextInfo);
 
-    CopyAsMarkdown.copyLink(linkText, info.linkUrl, { needEscape });
+      // TODO: If image has no text, but is wrapped in an HREF, then we might
+      //       get a description from there.
+      // TODO: Err, this should probably also be in the next section which handles
+      //       images!
+      if (info.mediaType === "image") {
+        needEscape = false;
+        linkText = "![]("+info.srcUrl+")";
+        // linkText = "![" + (contextInfo.data.alt || "") + "](" + contextInfo.data.src + ")";
+        linkText = contextInfo.data.alt || "";
+      } else {
+        linkText = info.selectionText ||
+          (contextInfo.data.innerText || "");
+        // Trust the link passed back, since it will recurse to find
+        // a link if necessary
+        info.linkUrl = contextInfo.data.href || info.linkUrl;
+      }
+      // Not sure how this will handle a link pre-provided in the linkText
+      CopyAsMarkdown.copyLink(linkText, info.linkUrl, { needEscape });
+    });
+
   }
 });
 
 chrome.contextMenus.create({
   parentId: copyAsMarkdownContextMenuId,
   title: "Image ![](src)", // TODO: how to fetch alt text?
+                           // XXX: just ask sfinktah!
+  // Using this test page: http://bl.ocks.org/mbostock/3680958 (and the image in the top left)
+  // we can see the following results from our console.logs in the content javascript:
+  // 
+  // sfinktah: received right-click for ![null](https://avatars.githubusercontent.com/u/230541?v=3&s=60)
+  // sfinktah: received right-click for [Mike Bostock](http://bl.ocks.org/mbostock)
+  //
+  // Evidentally there was no ALT text for that image, but this is also a limited case of there being
+  // a wrapping HREF that also contains inner text, that we can use as a description.
+  //
+  // Copy the above code and decide on what logic to employee (is ALT more important than LINK TEXT?)
   type: "normal",
   contexts: ["image"],
   onclick: function (info, tab) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,6 +30,10 @@
       "description": "all tabs: * [title](url)"
     }
   },
+  "content_scripts": [ {
+    "js": [ "content.js" ],
+    "matches": [ "http://*/*", "https://*/*" ]
+  } ],
   "options_ui": {
     "page": "options.html",
     "chrome_style": true


### PR DESCRIPTION
```
> location = "http://bl.ocks.org/mbostock/3680958"
< content.js:19 sfinktah: received right-click for ![null](https://avatars.githubusercontent.com/u/230541?v=3&s=60)
< content.js:33 sfinktah: received right-click for [Mike Bostock](http://bl.ocks.org/mbostock)
```

Another test (copying a regular link from the same page)

```
[SVG semantic zooming](http://bl.ocks.org/3680957)
```
