### PR TITLE
Don't use parent context menu

### DIFF
--- a/src/background/context-menus.js
+++ b/src/background/context-menus.js
@@ -47,33 +47,23 @@ function handler(info, tab) {
   return promise.then(response => flashSuccessBadge(response.size))
 }
 
-let parentID = browser.contextMenus.create({
-  id: "parent",
-  title: "Copy as Markdown",
-  type: "normal",
-  contexts: ["page", "link", "image"]
-});
-
 browser.contextMenus.create({
   id: "current-page",
-  parentId: parentID,
-  title: "Page [title](url)",
+  title: "Copy [Page Title](URL)",
   type: "normal",
   contexts: ["page"]
 });
 
 browser.contextMenus.create({
   id: "link",
-  parentId: parentID,
-  title: "Link [text or img](url)",
+  title: "Copy [Link Content](URL)",
   type: "normal",
   contexts: ["link"]
 });
 
 browser.contextMenus.create({
   id: "image",
-  parentId: parentID,
-  title: "Image ![](src)", // TODO: how to fetch alt text?
+  title: "Copy ![](Image URL)", // TODO: how to fetch alt text?
   type: "normal",
   contexts: ["image"]
 });


### PR DESCRIPTION
## Summary

Chrome & Firefox will merge them into a single parent when there are multiple items

<img width="308" alt="screen shot 2018-05-27 at 14 35 47" src="https://user-images.githubusercontent.com/10737/40582817-7927b3ea-61bb-11e8-820e-cee7f792d531.png">
<img width="239" alt="screen shot 2018-05-27 at 14 35 53" src="https://user-images.githubusercontent.com/10737/40582818-794e2c96-61bb-11e8-8603-b7515378e40f.png">
<img width="623" alt="screen shot 2018-05-27 at 14 37 07" src="https://user-images.githubusercontent.com/10737/40582819-79caed62-61bb-11e8-8abe-4bb68c94b410.png">

Solves #59 

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
