### PR TITLE
Listeners should be registered every time the background page is loaded

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,6 +2,7 @@ import contextMenuHandler from './context-menus.js';
 import messageHandler from './message-handler.js';
 import { flashSuccessBadge } from './badge.js';
 
+// Only create context menus when installed.
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     id: 'current-page',
@@ -23,26 +24,28 @@ chrome.runtime.onInstalled.addListener(() => {
     type: 'normal',
     contexts: ['image'],
   });
+});
 
-  chrome.contextMenus.onClicked.addListener(contextMenuHandler);
+// Listeners should be registered every time the background page is loaded.
 
-  // listen to keyboard shortcuts
-  chrome.commands.onCommand.addListener(async (command) => {
-    await messageHandler({
-      topic: 'copy',
-      params: {
-        action: command,
-      },
-    });
+chrome.contextMenus.onClicked.addListener(contextMenuHandler);
 
-    flashSuccessBadge();
+// listen to keyboard shortcuts
+chrome.commands.onCommand.addListener(async (command) => {
+  await messageHandler({
+    topic: 'copy',
+    params: {
+      action: command,
+    },
   });
 
-  // listen to messages from popup
-  chrome.runtime.onMessage.addListener(async (message) => {
-    await messageHandler(message);
+  flashSuccessBadge();
+});
 
-    // To avoid an error related to port closed before response
-    return true;
-  });
+// listen to messages from popup
+chrome.runtime.onMessage.addListener(async (message) => {
+  await messageHandler(message);
+
+  // To avoid an error related to port closed before response
+  return true;
 });


### PR DESCRIPTION
## Summary

The previous implementation will register listeners _only_ on installed or updated.

This patch ensures that every time the background is loaded, the listeners are registered properly.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
