### PR TITLE
Disable Chrome Event Page

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
   },
   "background": {
     "page": "./background.html",
-    "persistent": false
+    "persistent": true
   },
   "commands": {
     "current-tab-link": {


### PR DESCRIPTION
## Summary

Chrome Background Page must be running all the time, otherwise we cannot re-register listeners.

There must be something I don't understand in the doc https://developer.chrome.com/extensions/background_pages

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
