### PR TITLE
Persistent context menus

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,7 +2,13 @@ import contextMenuHandler from './context-menus.js';
 import messageHandler from './message-handler.js';
 import { flashSuccessBadge } from './badge.js';
 
-// Only create context menus when installed.
+// Always create context menus when running background page.
+// Since we don't use event page, this will presumably executed every time
+// the extension is loaded (once).
+//
+// NOTE: The examples shows that you need to use chrome.runtime.onInstalled,
+// but that's for non-persistent event page, not for persistent background page.
+// That example was used to prevent duplicate menu items.
 chrome.contextMenus.create({
   id: 'current-page',
   title: 'Copy [Page Title](URL)',
@@ -24,7 +30,7 @@ chrome.contextMenus.create({
   contexts: ['image'],
 });
 
-// Listeners should be registered every time the background page is loaded.
+// NOTE: All listeners must be registered at top level scope.
 
 chrome.contextMenus.onClicked.addListener(contextMenuHandler);
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -3,27 +3,25 @@ import messageHandler from './message-handler.js';
 import { flashSuccessBadge } from './badge.js';
 
 // Only create context menus when installed.
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.create({
-    id: 'current-page',
-    title: 'Copy [Page Title](URL)',
-    type: 'normal',
-    contexts: ['page'],
-  });
+chrome.contextMenus.create({
+  id: 'current-page',
+  title: 'Copy [Page Title](URL)',
+  type: 'normal',
+  contexts: ['page'],
+});
 
-  chrome.contextMenus.create({
-    id: 'link',
-    title: 'Copy [Link Content](URL)',
-    type: 'normal',
-    contexts: ['link'],
-  });
+chrome.contextMenus.create({
+  id: 'link',
+  title: 'Copy [Link Content](URL)',
+  type: 'normal',
+  contexts: ['link'],
+});
 
-  chrome.contextMenus.create({
-    id: 'image',
-    title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
-    type: 'normal',
-    contexts: ['image'],
-  });
+chrome.contextMenus.create({
+  id: 'image',
+  title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
+  type: 'normal',
+  contexts: ['image'],
 });
 
 // Listeners should be registered every time the background page is loaded.


### PR DESCRIPTION
## Summary

The old code was for Event Page model.

Since I removed Event Page and migrated to persistent Background Page #75, the context menus must be created when background page is loaded, not `onInstalled`.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
