### PR TITLE
Utilize optional permissions

### DIFF
--- a/src/background/badge.js
+++ b/src/background/badge.js
@@ -3,7 +3,7 @@ const COLOR_RED = '#d11b24';
 const COLOR_OPAQUE = [0, 0, 0, 255];
 
 const TEXT_OK = '✓';
-const TEXT_ERROR = '!';
+const TEXT_ERROR = '×';
 const TEXT_EMPTY = '';
 
 const FLASH_BADGE_TIMEOUT = 3000; // ms
@@ -26,7 +26,7 @@ async function clearBadge() {
   return setBadge(TEXT_EMPTY, COLOR_OPAQUE);
 }
 
-export async function flashBadge(type) {
+export default async function flashBadge(type) {
   switch (type) {
     case 'success':
       await setBadge(TEXT_OK, COLOR_GREEN);
@@ -39,8 +39,4 @@ export async function flashBadge(type) {
   }
 
   setTimeout(clearBadge, FLASH_BADGE_TIMEOUT);
-}
-
-export function flashSuccessBadge() {
-  return flashBadge('success');
 }

--- a/src/background/browser-as-markdown.js
+++ b/src/background/browser-as-markdown.js
@@ -11,7 +11,16 @@ const tabsToResult = {
  * @param {chrome.tabs.QueryInfo} query
  */
 function queryTabs(query) {
-  return new Promise((resolve) => chrome.tabs.query(query, resolve));
+  return new Promise((resolve, reject) => {
+    chrome.permissions.request({ permissions: ['tabs'] }, (granted) => {
+      // The callback argument will be true if the user granted the permissions.
+      if (granted) {
+        chrome.tabs.query(query, resolve);
+      } else {
+        reject(new Error('Permission Denied'));
+      }
+    });
+  });
 }
 
 export async function currentTab(options = {}) {

--- a/src/background/browser-as-markdown.js
+++ b/src/background/browser-as-markdown.js
@@ -12,7 +12,7 @@ const tabsToResult = {
  */
 function queryTabs(query) {
   return new Promise((resolve, reject) => {
-    chrome.permissions.request({ permissions: ['tabs'] }, (granted) => {
+    chrome.permissions.contains({ permissions: ['tabs'] }, (granted) => {
       // The callback argument will be true if the user granted the permissions.
       if (granted) {
         chrome.tabs.query(query, resolve);

--- a/src/background/context-menus.js
+++ b/src/background/context-menus.js
@@ -1,6 +1,6 @@
 import * as Markdown from './markdown.js';
 import copy from './clipboard-access.js';
-import { flashSuccessBadge } from './badge.js';
+import flashBadge from './badge.js';
 
 function tabAsMarkdown(tab) {
   return Markdown.linkTo(tab.title, tab.url);
@@ -54,5 +54,5 @@ export default async function contextMenuHandler(info, tab) {
   }
 
   await copy(markdown);
-  await flashSuccessBadge();
+  await flashBadge('success');
 }

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,6 @@
 import contextMenuHandler from './context-menus.js';
 import messageHandler from './message-handler.js';
-import { flashSuccessBadge } from './badge.js';
+import flashBadge from './badge.js';
 
 // Always create context menus when running background page.
 // Since we don't use event page, this will presumably executed every time
@@ -43,7 +43,7 @@ chrome.commands.onCommand.addListener(async (command) => {
     },
   });
 
-  flashSuccessBadge();
+  await flashBadge('success');
 });
 
 // listen to messages from popup

--- a/src/background/message-handler.js
+++ b/src/background/message-handler.js
@@ -1,6 +1,6 @@
 import * as BrowserAsMarkdown from './browser-as-markdown.js';
 import copy from './clipboard-access.js';
-import { flashSuccessBadge } from './badge.js';
+import flashBadge from './badge.js';
 
 async function handleCopy(action) {
   /** @type {string} */
@@ -51,24 +51,17 @@ async function handleCopy(action) {
   return text;
 }
 
-async function handleBadge(params) {
-  switch (params.action) {
-    case 'flashSuccess':
-      return flashSuccessBadge();
-
-    default:
-      throw new TypeError(`Unknown action: ${params.action}`);
-  }
-}
-
-export default function messageHandler({ topic = '', params = {} }) {
+export default async function messageHandler({ topic = '', params = {} }) {
   switch (topic) {
     case 'copy': {
-      return handleCopy(params.action);
-    }
+      try {
+        await handleCopy(params.action);
+        await flashBadge('success');
+      } catch (e) {
+        await flashBadge('fail');
+      }
 
-    case 'badge': {
-      return handleBadge(params);
+      break;
     }
 
     default: {

--- a/src/background/message-handler.js
+++ b/src/background/message-handler.js
@@ -57,11 +57,15 @@ export default async function messageHandler({ topic = '', params = {} }) {
       try {
         await handleCopy(params.action);
         await flashBadge('success');
+        return true;
       } catch (e) {
         await flashBadge('fail');
+        throw e;
       }
+    }
 
-      break;
+    case 'badge': {
+      return flashBadge(params.type);
     }
 
     default: {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,7 @@
     "clipboardWrite"
   ],
   "optional_permissions": [
+    "activeTab",
     "tabs"
   ],
   "browser_action": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,9 +5,11 @@
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
-    "tabs",
     "contextMenus",
     "clipboardWrite"
+  ],
+  "optional_permissions": [
+    "tabs"
   ],
   "browser_action": {
     "default_icon": "./images/icon-128.png",

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -16,24 +16,12 @@ async function doCopy(action) {
   });
 }
 
-async function showSuccessBadge() {
-  return sendMessageToBackgroundPage({
-    topic: 'badge',
-    params: {
-      action: 'flashSuccess',
-    },
-  });
-}
-
-function handler(event) {
-  doCopy(event.currentTarget.dataset.action);
-  showSuccessBadge();
-  window.close();
-}
-
 // Install listeners
 document.querySelectorAll('[data-action]').forEach((element) => {
-  element.addEventListener('click', handler);
+  element.addEventListener('click', async (event) => {
+    await doCopy(event.currentTarget.dataset.action);
+    window.close();
+  });
 });
 
 document.body.classList.add('custom-popup-style');

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -16,11 +16,31 @@ async function doCopy(action) {
   });
 }
 
+async function showBadge(type) {
+  return sendMessageToBackgroundPage({
+    topic: 'badge',
+    params: {
+      type,
+    },
+  });
+}
+
 // Install listeners
 document.querySelectorAll('[data-action]').forEach((element) => {
   element.addEventListener('click', async (event) => {
-    await doCopy(event.currentTarget.dataset.action);
-    window.close();
+    const { action } = event.currentTarget.dataset;
+
+    // NOTE: Firefox requires permission request to happen in a user interaction callback.
+    // Do not move this to background JS.
+    chrome.permissions.request({ permissions: ['tabs'] }, async (granted) => {
+      if (granted) {
+        await doCopy(action);
+      } else {
+        await showBadge('fail');
+      }
+
+      window.close();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Optionally request for controversial `tabs` permission when first click.

Note that it's still controversial that it grants `tabs` permission forever.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
