### PR TITLE
Request activeTab permission on demand (for Firefox)

### DIFF
--- a/src/background/context-menus.js
+++ b/src/background/context-menus.js
@@ -2,8 +2,25 @@ import * as Markdown from './markdown.js';
 import copy from './clipboard-access.js';
 import flashBadge from './badge.js';
 
-function tabAsMarkdown(tab) {
-  return Markdown.linkTo(tab.title, tab.url);
+async function tabAsMarkdown(info, tab) {
+  let { title } = tab;
+
+  if (!title) {
+    // Firefox does not grant activeTab automatically. Request optional permission on demand.
+    title = await new Promise((resolve, reject) => {
+      chrome.permissions.request({ permissions: ['activeTab'] }, (granted) => {
+        if (granted) {
+          chrome.tabs.getCurrent((currentTab) => {
+            resolve(currentTab.title);
+          });
+        } else {
+          reject(new Error('Permission Denied'));
+        }
+      });
+    });
+  }
+
+  return Markdown.linkTo(title, info.pageUrl);
 }
 
 function linkAsMarkdown(info) {
@@ -29,30 +46,33 @@ function imageAsMarkdown(info) {
   return Markdown.imageFor('', info.srcUrl);
 }
 
-export default async function contextMenuHandler(info, tab) {
-  let markdown;
-
+async function dispatchGetMarkdownCode(info, tab) {
   switch (info.menuItemId) {
     case 'current-page': {
-      markdown = tabAsMarkdown(tab);
-      break;
+      return tabAsMarkdown(info, tab);
     }
 
     case 'link': {
-      markdown = linkAsMarkdown(info);
-      break;
+      return linkAsMarkdown(info);
     }
 
     case 'image': {
-      markdown = imageAsMarkdown(info);
-      break;
+      return imageAsMarkdown(info);
     }
 
     default: {
       throw new TypeError(`unknown context menu: ${info}`);
     }
   }
+}
 
-  await copy(markdown);
-  await flashBadge('success');
+export default async function contextMenuHandler(info, tab) {
+  try {
+    const markdown = await dispatchGetMarkdownCode(info, tab);
+    await copy(markdown);
+    await flashBadge('success');
+  } catch (error) {
+    console.error(error);
+    await flashBadge('fail');
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,11 +5,11 @@
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
-    "activeTab",
     "contextMenus",
     "clipboardWrite"
   ],
   "optional_permissions": [
+    "activeTab",
     "tabs"
   ],
   "browser_action": {


### PR DESCRIPTION
## Summary

Chrome web store still rejects the extension due to extensive permissions. Let's try moving `activeTab` to optional permission, only for Firefox.

> Your product violates the "Use of Permissions" section of the policy, which requires that you:
> 
> - Request access to the narrowest permissions necessary to implement your product’s features or services.
> - If more than one permission could be used to implement a feature, you must request those with the least access to data or functionality.
> - Don't attempt to "future proof" your product by requesting a permission that might benefit services or features that have not yet been implemented.


## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
