### PR TITLE
Remove unnecessary activeTab permission

### DIFF
--- a/src/background/browser-as-markdown.js
+++ b/src/background/browser-as-markdown.js
@@ -11,15 +11,9 @@ const tabsToResult = {
  * @param {chrome.tabs.QueryInfo} query
  */
 function queryTabs(query) {
-  return new Promise((resolve, reject) => {
-    chrome.permissions.contains({ permissions: ['tabs'] }, (granted) => {
-      // The callback argument will be true if the user granted the permissions.
-      if (granted) {
-        chrome.tabs.query(query, resolve);
-      } else {
-        reject(new Error('Permission Denied'));
-      }
-    });
+  // optimistic -- user should have already granted 'tabs' permission on installation.
+  return new Promise((resolve) => {
+    chrome.tabs.query(query, resolve);
   });
 }
 

--- a/src/background/context-menus.js
+++ b/src/background/context-menus.js
@@ -6,15 +6,13 @@ async function tabAsMarkdown(info, tab) {
   let { title } = tab;
 
   if (!title) {
-    // Firefox does not grant activeTab automatically. Request optional permission on demand.
+    // Firefox does not grant activeTab automatically. Find current tab from tabs API instead.
     title = await new Promise((resolve, reject) => {
-      chrome.permissions.request({ permissions: ['activeTab'] }, (granted) => {
-        if (granted) {
-          chrome.tabs.getCurrent((currentTab) => {
-            resolve(currentTab.title);
-          });
+      chrome.tabs.getCurrent((currentTab) => {
+        if (currentTab) {
+          resolve(currentTab.title);
         } else {
-          reject(new Error('Permission Denied'));
+          reject(new Error('Could not retrieve current tab'));
         }
       });
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,10 +6,7 @@
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
     "contextMenus",
-    "clipboardWrite"
-  ],
-  "optional_permissions": [
-    "activeTab",
+    "clipboardWrite",
     "tabs"
   ],
   "browser_action": {

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -30,17 +30,9 @@ document.querySelectorAll('[data-action]').forEach((element) => {
   element.addEventListener('click', async (event) => {
     const { action } = event.currentTarget.dataset;
 
-    // NOTE: Firefox requires permission request to happen in a user interaction callback.
-    // Do not move this to background JS.
-    chrome.permissions.request({ permissions: ['tabs'] }, async (granted) => {
-      if (granted) {
-        await doCopy(action);
-      } else {
-        await showBadge('fail');
-      }
+    await doCopy(action);
 
-      window.close();
-    });
+    window.close();
   });
 });
 

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -16,15 +16,6 @@ async function doCopy(action) {
   });
 }
 
-async function showBadge(type) {
-  return sendMessageToBackgroundPage({
-    topic: 'badge',
-    params: {
-      type,
-    },
-  });
-}
-
 // Install listeners
 document.querySelectorAll('[data-action]').forEach((element) => {
   element.addEventListener('click', async (event) => {


### PR DESCRIPTION
## Summary

Per [discussion](https://groups.google.com/a/chromium.org/forum/?utm_medium=email&utm_source=footer#!msg/chromium-extensions/vUAxAWSD8fE/hwZRo8PCAgAJ) with Chrome Developer Support team, it is recommended not to include activeTab permission if not used (even if it's for Firefox compatibility).

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
